### PR TITLE
Tag the created docker image

### DIFF
--- a/docker_description.md
+++ b/docker_description.md
@@ -1,52 +1,65 @@
-#Summary
+## Summary
 
 We are running the sgx-trust-management for remote attestation from IBM in a docker container. All steps are run in the same docker container but this will be removed pending some port forwarding change. We are also running in simulation mode because I am issue #49576 in the process of getting regestered to run applications in hardware mode.
 
-#Setup
+## Setup
 
 (Note all docker commands on the server require prepending sudo. For best practice we should change this.)
 
 This should already have been done in njriasan on the server. If you reach problems in running a later step try redoing this.
 
+```
 git clone https://github.com/njriasan/sgx-trust-management.git
 
 cd cwd/sgx-trust-management
 
-docker build . (take the final hash produced END_HASH)
+docker build -t njriasan/trust-demo-image .
+```
 
-docker run -d --device /dev/isgx --device /dev/mei0 --name sgx-trust-demo-1 END_HASH
+If the container is not already running, you *may* need to do this step.
 
-#Launching Docker
+```
+docker run -d --device /dev/isgx --device /dev/mei0 --name sgx-trust-demo-1 njriasan/trust-demo-image
+```
 
+## Launching Docker
+
+You will always have to do these steps.
 (Reminder docker commands need sudo right now.)
 
 You will need 3 separate connections to the server (either 3 connections or by using t-mux). Run these in order in each terminal
 
-Terminal 1:
+### Terminal 1:
 
+```
 docker exec -t -i sgx-trust-demo-1 bash
 
 ./sgx-trust/service-provider/truce_server
+```
 
-Terminal 2:
+### Terminal 2:
 
+```
 docker exec -t -i sgx-trust-demo-1 bash
 
 cd sgx-trust/application/
 
 ./launch.sh
+```
 
-Terminal 3:
+### Terminal 3:
 
+```
 docker exec -t -i sgx-trust-demo-1 bash
 
 cd sgx-trust/client
 
 ./launch.sh
+```
 
 (Note this will send each person's name to the enclave via the truce server. By default we have simulated user's who know the contents and those who don't. Those who don't reject sending the secret.)
 
-#Future Work
+## Future Work
 
 - Run in hardware mode (waiting on intel)
 
@@ -54,7 +67,7 @@ cd sgx-trust/client
 
 - Run the client remotely and connect to the server (may need to do some configuration or route over ssh)
 
-#Possible Problems
+## Possible Problems
 
 Hash of file has changed before. I think I editted it but currently I just print it to update. I should figure out the exact hashing process and add a step to do that before runtime.
 


### PR DESCRIPTION
 so that it is easier to create the container from the image in the future
+ bonus fix, convert to markdown